### PR TITLE
Generate docs with ``` instead of ~~~~

### DIFF
--- a/src/DotNetMDDocs.Markdown/MDCode.cs
+++ b/src/DotNetMDDocs.Markdown/MDCode.cs
@@ -29,9 +29,9 @@ namespace DotNetMDDocs.Markdown
         {
             var stringBuilder = new StringBuilder();
 
-            stringBuilder.AppendLine($"~~~~{this.Language}");
+            stringBuilder.AppendLine($"```{this.Language}");
             stringBuilder.AppendLine(this.Code);
-            stringBuilder.AppendLine("~~~~");
+            stringBuilder.AppendLine("```");
 
             return stringBuilder.ToString();
         }


### PR DESCRIPTION
``` is far more common and documentation suggests using this syntax everywhere I have seen. Also at least some linters don't recognize the ~~~~ syntax.