### PR TITLE
Allow opt-out of doc generation

### DIFF
--- a/src/DotNetMDDocs/DotNetMDDocs.targets
+++ b/src/DotNetMDDocs/DotNetMDDocs.targets
@@ -1,18 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <GenerateMarkdownApiDocs Condition=" '$(GenerateMarkdownApiDocs)' == '' ">true</GenerateMarkdownApiDocs>
+  </PropertyGroup>
+
   <PropertyGroup Condition="$(DocumentationRootFolder) == ''">
     <DocumentationRootFolder Condition="$(OutputPath) != ''">$(OutputPath)docs</DocumentationRootFolder>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(OutputPath)|$(DocumentationRootFolder)' == '|'">
     <DocumentationRootFolder>bin\$(Configuration)\</DocumentationRootFolder>
-  
+
     <DocumentationRootFolder Condition="$(AppendTargetFrameworkToOutputPath) != 'false'">$(DocumentationRootFolder)$(TargetFramework)\</DocumentationRootFolder>
-  
+
     <DocumentationRootFolder>$(DocumentationRootFolder)docs</DocumentationRootFolder>
   </PropertyGroup>
-    
-  <Target Name="GenerateDocumentation" AfterTargets="Build">  
+
+  <Target Name="GenerateDocumentation" AfterTargets="Build" Condition=" '$(GenerateMarkdownApiDocs)' == 'true' ">
     <Exec Command="$(MSBuildThisFileDirectory)..\..\tools\DotNetMDDocs.exe --assembly-path $(TargetPath) --document-path $(DocumentationRootFolder)" LogStandardErrorAsError="true" />
   </Target>
 </Project>


### PR DESCRIPTION
This allows the project to only run the doc generation on release builds, or some other criteria.